### PR TITLE
Feat: Add linux/arm build support

### DIFF
--- a/.github/workflows/container.yaml
+++ b/.github/workflows/container.yaml
@@ -65,6 +65,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          platforms: linux/amd64,linux/arm/v5
       - name: Sign the published Docker image
         env:
           # https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable


### PR DESCRIPTION
This PR updates the Docker workflow to support building and pushing images for both linux/amd64 and linux/arm/v5 architectures.

@debloper This functionality is untested and requires further verification for compatibility and successful image publishing.