### PR TITLE
docs(intro): Fix cloud providers link

### DIFF
--- a/docs/src/content/docs/intro/index.mdx
+++ b/docs/src/content/docs/intro/index.mdx
@@ -42,7 +42,7 @@ There's no transcoding involved, so not only the stream quality remains the same
 
 <Xplex /> is **free and open source software**. You can run it on your own home server, or use a cloud server to host it. The only cost you would incur is the server cost; and the exact value depends on your cloud provider and their pricing of the compute unit of your choice.
 
-The [reference for choosing cloud providers](/refs/choose/clouds) has cost comparison for basic estimation. It also has **referral sign up links** with free credits for you to get started with the evaluation.
+The [reference for choosing cloud providers](/refs/choose/providers) has cost comparison for basic estimation. It also has **referral sign up links** with free credits for you to get started with the evaluation.
 
 ---
 


### PR DESCRIPTION
Fixed the link to the reference for choosing cloud providers from `choose/clouds` to `choose/providers`.