### PR TITLE
docs(postinstall): Fix change refs links

### DIFF
--- a/docs/src/content/docs/setup/postinstall.mdx
+++ b/docs/src/content/docs/setup/postinstall.mdx
@@ -17,7 +17,7 @@ You're now all set to proceed with configuring your ingest endpoints.
 ## Add Ingest Endpoints
 
 <Steps>
-1. **Get ingest URLs** for the streaming services you're planning to stream to. The guide to [collect ingest endpoints](/refs/manage/ingest) may come in handy.
+1. **Get ingest URLs** for the streaming services you're planning to stream to. The guide to [collect ingest endpoints](/refs/change/ingest) may come in handy.
 
 2. **Add Ingest URLs** to the `"Add new ingest URL"` field in <Xplex isHQ="true" /> dashboard and click `"Add Ingest"` button (or press <kbd>Enter</kbd>). Make sure the URLs are correct & properly formatted.
 
@@ -41,7 +41,7 @@ You're now all set to proceed with configuring your ingest endpoints.
    <Xplex /> will ignore the `stream key`, and just use the `server URL` for routing.
    :::
 
-2. **Review Encoding Settings** to ensure it uses [optimal encoding](/refs/manage/encoder) that's supported by ***ALL*** the platforms you're planning to stream to.
+2. **Review Encoding Settings** to ensure it uses [optimal encoding](/refs/change/encoder) that's supported by ***ALL*** the platforms you're planning to stream to.
 
    :::tip[Rule of Thumb]
    For maximum compatibility, stream at 1080p@30fps with a bitrate of 5000 Kbps.


### PR DESCRIPTION
- Fixed the link to the reference for choosing collecting ingest endpoints from `manage/ingest` to `change/ingest`.
- Fixed the link to the reference for optimal encoding from `manage/encoder` to `change/encoder`.